### PR TITLE
Remove redundant build flags

### DIFF
--- a/org.gnome.Boxes.json
+++ b/org.gnome.Boxes.json
@@ -21,8 +21,6 @@
         "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
     ],
     "build-options" : {
-        "cflags" : "-O2 -g",
-        "cxxflags" : "-O2 -g",
         "env" : {
         }
     },

--- a/org.gnome.Boxes.json
+++ b/org.gnome.Boxes.json
@@ -20,10 +20,6 @@
         "--talk-name=ca.desrt.dconf",
         "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
     ],
-    "build-options" : {
-        "env" : {
-        }
-    },
     "modules" : [
         {
             "name" : "mtools",


### PR DESCRIPTION
The 3.30 runtime sets these as defaults.