### PR TITLE
Prevent X11 access in a Wayland session with newer Flatpak

### DIFF
--- a/org.gnome.Boxes.json
+++ b/org.gnome.Boxes.json
@@ -6,6 +6,7 @@
     "command" : "gnome-boxes",
     "finish-args" : [
         "--share=ipc",
+        "--socket=fallback-x11",
         "--socket=x11",
         "--socket=wayland",
         "--socket=pulseaudio",


### PR DESCRIPTION
The unstable Flatpak 0.11.1 release added a `fallback-x11` socket that doesn't expose the XWayland socket inside a Wayland session if the application can run as a native Wayland client. However, if the application is being run by an older Flatpak, then this socket type is silently ignored, so it doesn't break compatibility.