### PR TITLE
Update libvirt to 4.7.0

### DIFF
--- a/org.gnome.Boxes.json
+++ b/org.gnome.Boxes.json
@@ -128,8 +128,8 @@
             "sources" : [
                 {
                     "type" : "archive",
-                    "url" : "https://libvirt.org/sources/libvirt-4.1.0.tar.xz",
-                    "sha256" : "8a2fa4826f311a936be8b7d4c8d76516c29417a593b1d1bb8641a8caaa316439"
+                    "url" : "https://libvirt.org/sources/libvirt-4.7.0.tar.xz",
+                    "sha256" : "92c279f7321624ac5a37a81f8bbe8c8d2a16781da04c63c99c92d3de035767e4"
                 }
             ]
         },


### PR DESCRIPTION
Thus fixes following security issues:
https://security.libvirt.org/2018/0005.html
https://security.libvirt.org/2018/0004.html

This also makes libvirt buildable against glibc 2.28