### PR TITLE
Remove redundant dependencies

### DIFF
--- a/org.gnome.Boxes.json
+++ b/org.gnome.Boxes.json
@@ -22,17 +22,6 @@
         "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
     ],
     "modules" : [
-         {
-            "name" : "libarchive",
-            "buildsystem" : "autotools",
-            "sources" : [
-                {
-                    "type" : "archive",
-                    "url" : "https://www.libarchive.org/downloads/libarchive-3.3.3.tar.gz",
-                    "sha256" : "ba7eb1781c9fbbae178c4c6bad1c6eb08edab9a1496c64833d1715d022b30e2e"
-                }
-            ]
-        },
         {
             "name" : "check",
             "sources" : [
@@ -417,16 +406,6 @@
                     "type" : "archive",
                     "url" : "http://pub.freerdp.com/releases/freerdp-2.0.0-rc2.tar.gz",
                     "sha256" : "bf080f71655a4996942436d5aacd5ce4afe57e546d4282fc0dc42fb80bd9da0c"
-                }
-            ]
-        },
-        {
-            "name" : "openssh",
-            "sources" : [
-                {
-                    "type" : "archive",
-                    "url" : "http://ftp.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-7.9p1.tar.gz",
-                    "sha256" : "6b4b3ba2253d84ed3771c8050728d597c91cfce898713beb7b64a305b6f11aad"
                 }
             ]
         },


### PR DESCRIPTION
libarchive and openssh are available in Platform.  Bundled openssh was vulnerable to multiple CVE: https://nvd.nist.gov/vuln/search/results?form_type=Advanced&cves=on&cpe_version=cpe%3a%2fa%3aopenbsd%3aopenssh%3a7.9%3ap1

BTW: intltool can be taken from [shared-modules](https://github.com/flathub/shared-modules/tree/master/intltool). Why you need to bundle own mesa?