### PR TITLE
Disable user-mode emulation targets in QEMU

### DIFF
--- a/org.gnome.Boxes.json
+++ b/org.gnome.Boxes.json
@@ -325,6 +325,7 @@
         {
             "name" : "qemu",
             "config-opts" : [
+                "--disable-user",
                 "--enable-kvm",
                 "--enable-spice",
                 "--enable-opengl",


### PR DESCRIPTION
They aren't required for gnome-boxes and take a lot of time to build.

Backporting https://gitlab.gnome.org/GNOME/gnome-boxes/commit/891a880faa7016e99106f8d8553d397fb296401e from upstream.

Original commit is 2 weeks old so it should be good to go in stable.