### PR TITLE
Update QEMU to 4.1.1

### DIFF
--- a/org.gnome.Boxes.json
+++ b/org.gnome.Boxes.json
@@ -337,8 +337,8 @@
             "sources" : [
                 {
                     "type" : "archive",
-                    "url" : "https://download.qemu.org/qemu-4.1.0.tar.xz",
-                    "sha256" : "656e60218689bdeec69903087fd7582d5d3e72238d02f4481d8dc6d79fd909c6"
+                    "url" : "https://download.qemu.org/qemu-4.1.1.tar.xz",
+                    "sha256" : "ed6fdbbdd272611446ff8036991e9b9f04a2ab2e3ffa9e79f3bab0eb9a95a1d2"
                 }
             ]
         },


### PR DESCRIPTION
This is important because this point release fixes various corruption
issues in qcow2 images.

See https://lists.gnu.org/archive/html/qemu-devel/2019-11/msg00481.html

This was initially proposed upstream in https://gitlab.gnome.org/GNOME/gnome-boxes/merge_requests/234

WIP. I want to perform some tests before merging.