### PR TITLE
Add dri for OpenGL

### DIFF
--- a/org.gnome.Boxes.json
+++ b/org.gnome.Boxes.json
@@ -18,6 +18,7 @@
         "--socket=pulseaudio",
         "--share=network",
         "--device=all",
+        "--device=dri",
         "--system-talk-name=org.freedesktop.timedate1",
         "--talk-name=org.gnome.ControlCenter",
         "--talk-name=org.gnome.Settings",


### PR DESCRIPTION
This is required if the user wants to do 3D Accelerated VMs