### PR TITLE
Set TMPDIR to an app-local temp directory to not exaust `/run`

### DIFF
--- a/org.gnome.Boxes.json
+++ b/org.gnome.Boxes.json
@@ -25,7 +25,8 @@
         "--filesystem=~/.config/dconf:ro",
         "--filesystem=host",
         "--talk-name=ca.desrt.dconf",
-        "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
+        "--env=DCONF_USER_CONFIG_DIR=.config/dconf",
+        "--env=TMPDIR=/var/tmp"
     ],
     "cleanup" : [
         "/usr",


### PR DESCRIPTION
See https://gitlab.gnome.org/GNOME/gnome-boxes/-/issues/1105 for more context.

By using the GLib default of `/tmp`, Boxes will write to the host directory `/run/user/$USER/app/org.gnome.Boxes`, which, when downloading large enough images, will completely fill the tmpfs and partially hose the system.

Telling GLib to use `/var/tmp`, this will be redirected by flatpak to the host directory `~/.var/app/org.gnome.Boxes/cache`. For something that may be XX GB in size, this seems to be a safer choice.

- - -

I've only tested with Flatseal to make the env change.