### PR TITLE
Update modules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "shared-modules"]
-	path = shared-modules
-	url = https://github.com/flathub/shared-modules.git

--- a/org.gnome.Boxes.json
+++ b/org.gnome.Boxes.json
@@ -64,8 +64,8 @@
                     "sources": [
                         {
                             "type": "archive",
-                            "url": "https://github.com/thom311/libnl/releases/download/libnl3_5_0/libnl-3.5.0.tar.gz",
-                            "sha256": "352133ec9545da76f77e70ccb48c9d7e5324d67f6474744647a7ed382b5e05fa"
+                            "url": "https://github.com/thom311/libnl/releases/download/libnl3_12_0/libnl-3.12.0.tar.gz",
+                            "sha256": "fc51ca7196f1a3f5fdf6ffd3864b50f4f9c02333be28be4eeca057e103c0dd18"
                         }
                     ]
                 },

--- a/org.gnome.Boxes.json
+++ b/org.gnome.Boxes.json
@@ -263,8 +263,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.qemu.org/qemu-11.0.0.tar.xz",
-                    "sha256": "c04ca36012653f32d11c674d370cf52a710e7d3f18c2d8b63e4932052a4854d6"
+                    "url": "https://download.qemu.org/qemu-11.0.1.tar.xz",
+                    "sha256": "0d235f5820278d914a3155ec27af8e4258d697ea892895570807d69c0cb8cd64"
                 }
             ],
             "modules": [
@@ -274,8 +274,8 @@
                     "sources": [
                         {
                             "type": "archive",
-                            "url": "https://gitlab.freedesktop.org/-/project/2767/uploads/ed8eaeada090f91a640c8e8e01d704bc/libslirp-4.9.1.tar.xz",
-                            "sha256": "3470767abf6d269ea9497422302c98d46ace45a70fbe9f88583b154282a2c5c0"
+                            "url": "https://gitlab.freedesktop.org/-/project/2767/uploads/bdcbb727b502f93d312e631cc0980055/libslirp-4.9.3.tar.xz",
+                            "sha256": "be4edb819fb29a51dcbeeb3ada7e39b05fd0841ce2a1259187ba928ee197cf45"
                         }
                     ]
                 },
@@ -340,8 +340,8 @@
                     "sources": [
                         {
                             "type": "archive",
-                            "url": "https://git.kernel.org/pub/scm/utils/dtc/dtc.git/snapshot/v1.7.2.tar.gz",
-                            "sha256": "04a30bd38b426ed771b8a8b5d9b773e54976d4f5d51a80a9e76a45b20c9a8272"
+                            "url": "https://git.kernel.org/pub/scm/utils/dtc/dtc.git/snapshot/v1.8.1.tar.gz",
+                            "sha256": "a6bea318d8d4c80ad9637a0c94571ba1148d482604006f02b70e70126ac2310b"
                         }
                     ]
                 }

--- a/org.gnome.Boxes.json
+++ b/org.gnome.Boxes.json
@@ -315,8 +315,8 @@
                     "sources": [
                         {
                             "type": "file",
-                            "url": "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl",
-                            "sha256": "9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16"
+                            "url": "https://files.pythonhosted.org/packages/02/08/9c41fb51ab5b43eb21674aff13df270e8ba6c4b29c8624e328dc7a9482af/distlib-0.4.3-py2.py3-none-any.whl",
+                            "sha256": "4b0ce306c966eb73bc3a7b6abad017c556dadd92c44701562cd528ac7fde4d5b"
                         }
                     ]
                 },

--- a/org.gnome.Boxes.json
+++ b/org.gnome.Boxes.json
@@ -264,8 +264,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.qemu.org/qemu-10.2.2.tar.xz",
-                    "sha256": "784b296ff29c1417aa72323abcb2d2ea9ab9771724f577dcd785c3b04f21e176"
+                    "url": "https://download.qemu.org/qemu-11.0.0.tar.xz",
+                    "sha256": "c04ca36012653f32d11c674d370cf52a710e7d3f18c2d8b63e4932052a4854d6"
                 }
             ],
             "modules": [

--- a/org.gnome.Boxes.json
+++ b/org.gnome.Boxes.json
@@ -300,8 +300,49 @@
                     "sources": [
                         {
                             "type": "archive",
-                            "url": "https://gitlab.freedesktop.org/virgl/virglrenderer/-/archive/0.10.4/virglrenderer-0.10.4.tar.gz",
-                            "sha256": "da3fdc59821f645632d986482594410614a95c0c7c703b25bfb3473bd6674214"
+                            "url": "https://gitlab.freedesktop.org/virgl/virglrenderer/-/archive/1.3.0/virglrenderer-1.3.0.tar.gz",
+                            "sha256": "065bc56e89e6f631f96101cd62eba0748e48eb888b434edc86e89d05395e76f3"
+                        }
+                    ],
+                    "modules": [
+                        {
+                            "name": "python3-pyyaml",
+                            "buildsystem": "simple",
+                            "build-commands": [
+                                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"pyyaml\" --no-build-isolation"
+                            ],
+                            "sources": [
+                                {
+                                    "type": "file",
+                                    "url": "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz",
+                                    "sha256": "d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "python3-distlib",
+                    "buildsystem": "simple",
+                    "build-commands": [
+                        "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"distlib\" --no-build-isolation"
+                    ],
+                    "sources": [
+                        {
+                            "type": "file",
+                            "url": "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl",
+                            "sha256": "9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16"
+                        }
+                    ]
+                },
+                {
+                    "name": "dtc",
+                    "buildsystem": "meson",
+                    "sources": [
+                        {
+                            "type": "archive",
+                            "url": "https://git.kernel.org/pub/scm/utils/dtc/dtc.git/snapshot/v1.7.2.tar.gz",
+                            "sha256": "04a30bd38b426ed771b8a8b5d9b773e54976d4f5d51a80a9e76a45b20c9a8272"
                         }
                     ]
                 }

--- a/org.gnome.Boxes.json
+++ b/org.gnome.Boxes.json
@@ -275,8 +275,8 @@
                     "sources": [
                         {
                             "type": "archive",
-                            "url": "https://gitlab.freedesktop.org/slirp/libslirp//-/archive/v4.7.0.tar.gz",
-                            "sha256": "ccfd4e330b3d59be19e0cce25b0da000d61bcee2cfb608eb23418920d991a6da"
+                            "url": "https://gitlab.freedesktop.org/-/project/2767/uploads/ed8eaeada090f91a640c8e8e01d704bc/libslirp-4.9.1.tar.xz",
+                            "sha256": "3470767abf6d269ea9497422302c98d46ace45a70fbe9f88583b154282a2c5c0"
                         }
                     ]
                 },

--- a/org.gnome.Boxes.json
+++ b/org.gnome.Boxes.json
@@ -85,12 +85,11 @@
                 },
                 {
                     "name": "rpcsvc-proto",
-                    "buildsystem": "autotools",
                     "sources": [
                         {
                             "type": "archive",
-                            "url": "https://github.com/thkukuk/rpcsvc-proto/archive/v1.4.1.tar.gz",
-                            "sha256": "750f7e57b81407a25b707867e90d7ee80aeb53bf515b114fc218f3c78dc9a6e8"
+                            "url": "https://github.com/thkukuk/rpcsvc-proto/releases/download/v1.4.4/rpcsvc-proto-1.4.4.tar.xz",
+                            "sha256": "81c3aa27edb5d8a18ef027081ebb984234d5b5860c65bd99d4ac8f03145a558b"
                         }
                     ]
                 },

--- a/org.gnome.Boxes.json
+++ b/org.gnome.Boxes.json
@@ -232,7 +232,6 @@
                 },
                 {
                     "name": "spice",
-                    "buildsystem": "autotools",
                     "config-opts": [
                         "--disable-lz4",
                         "--disable-manual",
@@ -241,8 +240,8 @@
                     "sources": [
                         {
                             "type": "archive",
-                            "url": "https://www.spice-space.org/download/releases/spice-0.15.1.tar.bz2",
-                            "sha256": "ada9af67ab321916bd7eb59e3d619a4a7796c08a28c732edfc7f02fc80b1a37a"
+                            "url": "https://www.spice-space.org/download/releases/spice-0.16.0.tar.bz2",
+                            "sha256": "0a6ec9528f05371261bbb2d46ff35e7b5c45ff89bb975a99af95a5f20ff4717d"
                         }
                     ]
                 }

--- a/org.gnome.Boxes.json
+++ b/org.gnome.Boxes.json
@@ -166,20 +166,6 @@
             ],
             "modules": [
                 {
-                    "name": "python3-six",
-                    "buildsystem": "simple",
-                    "build-commands": [
-                        "pip3 install --prefix=/app six-1.17.0-py2.py3-none-any.whl"
-                    ],
-                    "sources": [
-                        {
-                            "type": "file",
-                            "url": "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl",
-                            "sha256": "4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274"
-                        }
-                    ]
-                },
-                {
                     "name": "spice-protocol",
                     "buildsystem": "meson",
                     "sources": [

--- a/org.gnome.Boxes.json
+++ b/org.gnome.Boxes.json
@@ -264,8 +264,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.qemu.org/qemu-9.1.3.tar.xz",
-                    "sha256": "480a77a0ed13a9b39415f639aa020b4eb0d7cc5a52569510dfd830b3af1bac89"
+                    "url": "https://download.qemu.org/qemu-10.2.2.tar.xz",
+                    "sha256": "784b296ff29c1417aa72323abcb2d2ea9ab9771724f577dcd785c3b04f21e176"
                 }
             ],
             "modules": [

--- a/org.gnome.Boxes.json
+++ b/org.gnome.Boxes.json
@@ -289,8 +289,8 @@
                     "sources": [
                         {
                             "type": "archive",
-                            "url": "https://spice-space.org/download/usbredir/usbredir-0.13.0.tar.xz",
-                            "sha256": "4ba6faa02c0ae6deeb4c53883d66ab54b3a5899bead42ce4ded9568b9a7dc46e"
+                            "url": "https://www.spice-space.org/download/usbredir/usbredir-0.15.0.tar.xz",
+                            "sha256": "6dc2a380277688a068191245dac2ab7063a552999d8ac3ad8e841c10ff050961"
                         }
                     ]
                 },

--- a/org.gnome.Boxes.json
+++ b/org.gnome.Boxes.json
@@ -114,8 +114,8 @@
                     "sources": [
                         {
                             "type": "archive",
-                            "url": "https://download.libvirt.org/libvirt-12.2.0.tar.xz",
-                            "sha256": "ac93cd0da743a6c231911fb549399b415102ecfee775329bebbf61ed843b9786"
+                            "url": "https://download.libvirt.org/libvirt-12.3.0.tar.xz",
+                            "sha256": "0d2b548d1b732d1ae21cfefacc204a2c8dabada80ea1edfbd528bfb73b9d2d27"
                         },
                         {
                             "type": "patch",

--- a/org.gnome.Boxes.json
+++ b/org.gnome.Boxes.json
@@ -225,8 +225,8 @@
                     "sources": [
                         {
                             "type": "archive",
-                            "url": "https://www.spice-space.org/download/libcacard/libcacard-2.8.1.tar.xz",
-                            "sha256": "fbbf4de8cb7db5bdff5ecb672ff0dbe6939fb9f344b900d51ba6295329a332e7"
+                            "url": "https://www.spice-space.org/download/libcacard/libcacard-2.8.2.tar.xz",
+                            "sha256": "45fc28a6ff3c7a359d4448132ca190f0a9c760540c445dba4597a5b71de40f68"
                         }
                     ]
                 },

--- a/org.gnome.Boxes.json
+++ b/org.gnome.Boxes.json
@@ -47,7 +47,6 @@
         }
     },
     "modules": [
-        "shared-modules/intltool/intltool-0.51.json",
         {
             "name": "libvirt-glib",
             "buildsystem": "meson",

--- a/org.gnome.Boxes.json
+++ b/org.gnome.Boxes.json
@@ -160,8 +160,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://www.spice-space.org/download/gtk/spice-gtk-0.42.tar.xz",
-                    "sha256": "9380117f1811ad1faa1812cb6602479b6290d4a0d8cc442d44427f7f6c0e7a58"
+                    "url": "https://gitlab.freedesktop.org/-/project/64/uploads/88f5d31a961da9921add46ca3f0be904/spice-gtk-0.43.tar.xz",
+                    "sha256": "cee26e5b2d22909f35b40a94398d1e863ca3962ee46494ca97aab206abc3203b"
                 }
             ],
             "modules": [

--- a/org.gnome.Boxes.json
+++ b/org.gnome.Boxes.json
@@ -115,8 +115,8 @@
                     "sources": [
                         {
                             "type": "archive",
-                            "url": "https://libvirt.org/sources/libvirt-11.7.0.tar.xz",
-                            "sha256": "dd56db0ced8baf668f476698db9956f160c93c0ec0c47a0603843235bf156f78"
+                            "url": "https://download.libvirt.org/libvirt-12.2.0.tar.xz",
+                            "sha256": "ac93cd0da743a6c231911fb549399b415102ecfee775329bebbf61ed843b9786"
                         },
                         {
                             "type": "patch",

--- a/org.gnome.Boxes.json
+++ b/org.gnome.Boxes.json
@@ -186,8 +186,8 @@
                     "sources": [
                         {
                             "type": "archive",
-                            "url": "https://www.spice-space.org/download/releases/spice-protocol-0.14.3.tar.xz",
-                            "sha256": "f986e5bc2a1598532c4897f889afb0df9257ac21c160c083703ae7c8de99487a"
+                            "url": "https://www.spice-space.org/download/releases/spice-protocol-0.14.5.tar.xz",
+                            "sha256": "baf58449f6e89d19f475899ad5fb9196fdc46c03cc53233f4e39cf2978f9cff7"
                         }
                     ]
                 },

--- a/org.gnome.Boxes.json
+++ b/org.gnome.Boxes.json
@@ -210,13 +210,13 @@
                     "name": "python-pyparsing",
                     "buildsystem": "simple",
                     "build-commands": [
-                        "pip3 install --prefix=/app pyparsing-2.4.6-py2.py3-none-any.whl"
+                        "pip3 install --prefix=/app pyparsing-3.3.2-py3-none-any.whl"
                     ],
                     "sources": [
                         {
                             "type": "file",
-                            "url": "https://files.pythonhosted.org/packages/5d/bc/1e58593167fade7b544bfe9502a26dc860940a79ab306e651e7f13be68c2/pyparsing-2.4.6-py2.py3-none-any.whl",
-                            "sha256": "c342dccb5250c08d45fd6f8b4a559613ca603b57498511740e65cd11a2e7dcec"
+                            "url": "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl",
+                            "sha256": "850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d"
                         }
                     ]
                 },

--- a/org.gnome.Boxes.json
+++ b/org.gnome.Boxes.json
@@ -264,8 +264,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.qemu.org/qemu-7.2.0.tar.xz",
-                    "sha256": "5b49ce2687744dad494ae90a898c52204a3406e84d072482a1e1be854eeb2157"
+                    "url": "https://download.qemu.org/qemu-9.1.3.tar.xz",
+                    "sha256": "480a77a0ed13a9b39415f639aa020b4eb0d7cc5a52569510dfd830b3af1bac89"
                 }
             ],
             "modules": [

--- a/org.gnome.Boxes.json
+++ b/org.gnome.Boxes.json
@@ -114,8 +114,8 @@
                     "sources": [
                         {
                             "type": "archive",
-                            "url": "https://download.libvirt.org/libvirt-12.4.0.tar.xz",
-                            "sha256": "c86c7f758391b895ec90f76f965a56266167028978ac6dce824fea4d6a036b6d"
+                            "url": "https://download.libvirt.org/libvirt-12.6.0.tar.xz",
+                            "sha256": "1592256deb76fc94028ff083a4d9f06a74f3b92a66a1794f37bc26f21430c888"
                         },
                         {
                             "type": "patch",
@@ -249,8 +249,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.qemu.org/qemu-11.0.1.tar.xz",
-                    "sha256": "0d235f5820278d914a3155ec27af8e4258d697ea892895570807d69c0cb8cd64"
+                    "url": "https://download.qemu.org/qemu-11.0.3.tar.xz",
+                    "sha256": "da5fcffc32762820568b828ed430a728864d34d50b6d2f30358597760cbb0523"
                 }
             ],
             "modules": [
@@ -466,8 +466,8 @@
                 {
                     "type": "git",
                     "url": "https://github.com/flatpak/libportal",
-                    "tag": "0.9.1",
-                    "commit": "8f5dc8d192f6e31dafe69e35219e3b707bde71ce",
+                    "tag": "0.10.0",
+                    "commit": "c23024018c8eb076549a1517fcb2d7f80d3e2ed5",
                     "x-checker-data": {
                         "type": "git",
                         "url": "https://github.com/flatpak/libportal",

--- a/org.gnome.Boxes.json
+++ b/org.gnome.Boxes.json
@@ -114,8 +114,8 @@
                     "sources": [
                         {
                             "type": "archive",
-                            "url": "https://download.libvirt.org/libvirt-12.3.0.tar.xz",
-                            "sha256": "0d2b548d1b732d1ae21cfefacc204a2c8dabada80ea1edfbd528bfb73b9d2d27"
+                            "url": "https://download.libvirt.org/libvirt-12.4.0.tar.xz",
+                            "sha256": "c86c7f758391b895ec90f76f965a56266167028978ac6dce824fea4d6a036b6d"
                         },
                         {
                             "type": "patch",


### PR DESCRIPTION
Tried this because Ubuntu 24.04.4 kept failing to install; it works now. I haven't done more testing, but my first impression is that it works.

Maybe adding x-checker-data with `require-important` flag would be sensible to automate that and get updates for the modules along with updates to the gnome-boxes module?